### PR TITLE
Detect the object-level redundancy issue

### DIFF
--- a/src/ciir/umass/edu/learning/tree/FeatureHistogram.java
+++ b/src/ciir/umass/edu/learning/tree/FeatureHistogram.java
@@ -315,6 +315,9 @@ public class FeatureHistogram {
 			for(int i=0;i<workers.length;i++)
 			{
 				Worker wk = (Worker)workers[i];
+				if (wk == null || wk.cfg == null) {
+					break;
+				}
 				if(best.S < wk.cfg.S)
 					best = wk.cfg;
 			}		
@@ -435,6 +438,40 @@ public class FeatureHistogram {
 			this.sampleSortedIdx = sampleSortedIdx;
 			this.thresholds = thresholds;			
 		}
+
+		public void set(Object _w) {
+			Worker w = (Worker)_w;
+			// if (w.type == 0) {
+			this.type = w.type;
+			this.fh = w.fh;
+			this.usedFeatures = w.usedFeatures;
+			this.minLeafSup = w.minLeafSup;
+
+			// } else if (w.type == 1){
+			// type = 1;
+			this.fh = w.fh;
+			this.labels = w.labels;
+			// } else if (w.type == 2) {
+			// type = 2;
+			this.fh = w.fh;
+			this.parent = w.parent;
+			this.soi = w.soi;
+			this.labels = w.labels;
+			// } else if (w.type == 3) {
+			// type = 3;
+			this.fh = w.fh;
+			this.parent = w.parent;
+			this.leftSibling = w.leftSibling;
+			// } else if(w.type ==4) {
+			// type = 4;
+			this.fh = w.fh;
+			this.samples = w.samples;
+			this.labels = w.labels;
+			this.sampleSortedIdx = w.sampleSortedIdx;
+			this.thresholds = w.thresholds;			
+			this.finished = false;
+			// }
+		}
 		public void run()
 		{
 			if(type == 0)
@@ -447,6 +484,7 @@ public class FeatureHistogram {
 				fh.construct(parent, leftSibling, start, end);
 			else if(type == 4)
 				fh.construct(samples, labels, sampleSortedIdx, thresholds, start, end);
+			this.finished = true;
 		}		
 		public WorkerThread clone()
 		{

--- a/src/ciir/umass/edu/utilities/MyThreadPool.java
+++ b/src/ciir/umass/edu/utilities/MyThreadPool.java
@@ -47,20 +47,55 @@ public class MyThreadPool extends ThreadPoolExecutor {
 	{
 		return size;
 	}
+	private WorkerThread[] workers = null;
 	public WorkerThread[] execute(WorkerThread worker, int nTasks)
 	{
+// StackTraceElement[] _element = Thread.currentThread().getStackTrace();
+// System.err.println("<--");
+// for (int i = 0 ;i < _element.length; i++){
+// 	System.err.println(_element[i]);
+// }
+// System.err.println("-->");
+// System.err.println("entry");
+
+		try {
+			this.semaphore.acquire(nTasks);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
 		MyThreadPool p = MyThreadPool.getInstance();
 		int[] partition = p.partition(nTasks);
-		WorkerThread[] workers = new WorkerThread[partition.length-1];
+		// WorkerThread[] workers = new WorkerThread[partition.length-1];
+		if (workers == null) {
+			workers = new WorkerThread[partition.length-1];
+		} else if (workers.length < partition.length - 1) {
+			WorkerThread[] tmp = new WorkerThread[partition.length-1];
+			System.arraycopy(workers, 0, tmp, 0, workers.length);
+			workers = tmp;
+		}
 		for(int i=0;i<partition.length-1;i++)
 		{
-			WorkerThread w = worker.clone();
+			// WorkerThread w = worker.clone();
+			WorkerThread w = workers[i];
+			if (w == null) {
+				w = worker.clone();
+				workers[i] = w;
+			}
 			w.set(partition[i], partition[i+1]-1);
+			// w.set(worker);
 			workers[i] = w;
-			p.execute(w);
+			p.execute0(w);
 		}
-		await();
+		await0(workers);
+		// await();
+// System.err.println("leave");
 		return workers;
+	}
+
+	public void await0(WorkerThread[] threads) {
+		for (int i = 0; i < threads.length; ++i) {
+			while (!threads[i].finished);
+		}
 	}
 	
 	public void await()
@@ -90,6 +125,16 @@ public class MyThreadPool extends ThreadPoolExecutor {
 		return partition;
 	}
 	
+	public void execute0(Runnable task) 
+	{
+		try {
+			super.execute(task);
+		}
+		catch(Exception ex)
+		{
+			throw RankLibError.create("Error in MyThreadPool.execute(): ", ex);
+		}
+	}
 	
 	public void execute(Runnable task) 
 	{

--- a/src/ciir/umass/edu/utilities/WorkerThread.java
+++ b/src/ciir/umass/edu/utilities/WorkerThread.java
@@ -9,4 +9,6 @@ public abstract class WorkerThread implements Runnable {
 		this.end = end;
 	}
 	public abstract WorkerThread clone();
+	public volatile boolean finished = false;
+	public abstract void set(Object o);
 }


### PR DESCRIPTION
Hello, we run ranklib with our tool and detected the object-level redundancy issues. In MyThreadPool.java, the object w (of type WorkerThread) is repeatedly created, which incurs significant overhead. In fact, it could be reused. The optimized code is in this pull request.